### PR TITLE
feat: publish issuer/brand under arbitrary name

### DIFF
--- a/contract/src/arbAssetNames.js
+++ b/contract/src/arbAssetNames.js
@@ -7,6 +7,7 @@ import { E, Far } from '@endo/far';
 import { M, mustMatch } from '@endo/patterns';
 import { AmountShape } from '@agoric/ertp/src/typeGuards.js';
 import { atomicRearrange } from '@agoric/zoe/src/contractSupport/atomicTransfer.js';
+import { getTerms } from './contractMetaAux.js';
 
 const { Fail, quote: q } = assert;
 
@@ -22,11 +23,15 @@ const PublishProposalShape = {
 };
 
 /** @type {import("./types").ContractMeta} */
-const meta = {
+export const meta = harden({
   privateArgsShape: {
     nameAdmins: { issuer: M.remotable(), brand: M.remotable() },
   },
-};
+  customTermsShape: {
+    board: M.remotable('board'),
+    price: AmountShape,
+  },
+});
 
 /**
  *
@@ -42,7 +47,8 @@ const meta = {
  * @param {*} baggage
  */
 export const start = async (zcf, privateArgs, baggage) => {
-  const { board, price } = zcf.getTerms();
+  const { board, price } = getTerms(zcf, meta);
+  mustMatch(privateArgs, meta.privateArgsShape);
   const { nameAdmins } = privateArgs;
 
   /**

--- a/contract/src/arbAssetNames.js
+++ b/contract/src/arbAssetNames.js
@@ -1,0 +1,96 @@
+/**
+ * @file Prototype Decentralized Asset Naming
+ * @see {start}
+ */
+// @ts-check
+import { E, Far } from '@endo/far';
+import { M, mustMatch } from '@endo/patterns';
+import { AmountShape } from '@agoric/ertp/src/typeGuards.js';
+import { atomicRearrange } from '@agoric/zoe/src/contractSupport/atomicTransfer.js';
+
+const { Fail, quote: q } = assert;
+
+const AssetInfoShape = harden({
+  issuer: M.remotable('Issuer'),
+  brand: M.remotable('Brand'),
+});
+
+const PublishProposalShape = {
+  give: { Pay: AmountShape },
+  want: {},
+  exit: M.any(),
+};
+
+/** @type {import("./types").ContractMeta} */
+const meta = {
+  privateArgsShape: {
+    nameAdmins: { issuer: M.remotable(), brand: M.remotable() },
+  },
+};
+
+/**
+ *
+ * @typedef {{
+ *   board: import('@agoric/vats/src/types').Board,
+ *   price: Amount,
+ * }} BoardTerms
+ * @param {ZCF<BoardTerms>} zcf
+ * @param {{ nameAdmins: {
+ *   issuer: import('@agoric/vats/src/types').NameAdmin,
+ *   brand: import('@agoric/vats/src/types').NameAdmin
+ * }}} privateArgs
+ * @param {*} baggage
+ */
+export const start = async (zcf, privateArgs, baggage) => {
+  const { board, price } = zcf.getTerms();
+  const { nameAdmins } = privateArgs;
+
+  /**
+   * @param {Issuer} issuer
+   * @param {Brand} brand
+   */
+  const prepare = async (issuer, brand) => {
+    mustMatch(harden({ issuer, brand }), AssetInfoShape);
+    // Check: issuer and brand recognize each other
+    const issuerBrand = await E(issuer).getBrand();
+    issuerBrand === brand ||
+      Fail`issuer ${q(issuer)}'s brand is ${q(issuerBrand)} not ${q(brand)}`;
+    const issuerOk = await E(brand).isMyIssuer(issuer);
+    issuerOk || Fail`brand ${q(brand)} does not recognize ${q(issuer)}`;
+
+    // Check: issuer makes purses with the same brand
+    const aPurse = await E(issuer).makeEmptyPurse();
+    const purseBrand = await E(aPurse).getAllegedBrand();
+    purseBrand === brand ||
+      Fail`issuer ${q(issuer)}'s purse's brand is ${q(purseBrand)} not ${q(
+        brand,
+      )}`;
+  };
+
+  /**
+   * @param {Issuer} issuer
+   * @param {Brand} brand
+   */
+  const commit = async (issuer, brand) => {
+    const name = await E(board).getId(brand);
+    await Promise.all([
+      E(nameAdmins.issuer).update(name, issuer),
+      E(nameAdmins.brand).update(name, brand),
+    ]);
+    return name;
+  };
+
+  const { zcfSeat: proceeds } = zcf.makeEmptySeatKit();
+  const publishHandler = async (seat, offerArgs) => {
+    mustMatch(harden(offerArgs), AssetInfoShape);
+    atomicRearrange(zcf, [[seat, proceeds, { Pay: price }]]);
+    const { issuer, brand } = offerArgs;
+    await prepare(issuer, brand);
+    const name = await commit(issuer, brand);
+    return name;
+  };
+  const makePublishAssetInvitation = () =>
+    zcf.makeInvitation(publishHandler, 'publishAsset', PublishProposalShape);
+  const publicFacet = Far('Arb Asset Naming', { makePublishAssetInvitation });
+  return { publicFacet };
+};

--- a/contract/src/arbAssetNames.js
+++ b/contract/src/arbAssetNames.js
@@ -16,11 +16,11 @@ const AssetInfoShape = harden({
   brand: M.remotable('Brand'),
 });
 
-const PublishProposalShape = {
+const PublishProposalShape = harden({
   give: { Pay: AmountShape },
   want: {},
   exit: M.any(),
-};
+});
 
 /** @type {import("./types").ContractMeta} */
 export const meta = harden({
@@ -89,14 +89,19 @@ export const start = async (zcf, privateArgs, baggage) => {
   const { zcfSeat: proceeds } = zcf.makeEmptySeatKit();
   const publishHandler = async (seat, offerArgs) => {
     mustMatch(harden(offerArgs), AssetInfoShape);
-    atomicRearrange(zcf, [[seat, proceeds, { Pay: price }]]);
+    atomicRearrange(zcf, harden([[seat, proceeds, { Pay: price }]]));
     const { issuer, brand } = offerArgs;
     await prepare(issuer, brand);
     const name = await commit(issuer, brand);
     return name;
   };
   const makePublishAssetInvitation = () =>
-    zcf.makeInvitation(publishHandler, 'publishAsset', PublishProposalShape);
+    zcf.makeInvitation(
+      publishHandler,
+      'publishAsset',
+      undefined,
+      PublishProposalShape,
+    );
   const publicFacet = Far('Arb Asset Naming', { makePublishAssetInvitation });
   return { publicFacet };
 };

--- a/contract/src/contractMetaAux.js
+++ b/contract/src/contractMetaAux.js
@@ -1,0 +1,20 @@
+// @ts-check
+import { mustMatch } from '@endo/patterns';
+
+/**
+ * meta.customTermsShape doesn't seem to work.
+ *
+ * @template CT
+ * @param {ZCF<CT>} zcf
+ * @param {import('./types').ContractMeta} meta
+ * @returns {CT & StandardTerms}
+ */
+export const getTerms = (zcf, meta) => {
+  const terms = zcf.getTerms();
+  const { customTermsShape } = meta;
+  if (customTermsShape) {
+    const { issuers: _i, brands: _b, ...customTerms } = terms;
+    mustMatch(harden(customTerms), customTermsShape);
+  }
+  return terms;
+};

--- a/contract/src/postalSvc.js
+++ b/contract/src/postalSvc.js
@@ -1,9 +1,15 @@
 // @ts-check
 import { E, Far } from '@endo/far';
-import { M, mustMatch } from '@endo/patterns';
+import { M } from '@endo/patterns';
 import { withdrawFromSeat } from '@agoric/zoe/src/contractSupport/zoeHelpers.js';
+import { getTerms } from './contractMetaAux.js';
 
 const { keys, values } = Object;
+
+/** @type {import("./types").ContractMeta} */
+export const meta = harden({
+  customTermsShape: { namesByAddress: M.remotable('namesByAddress') },
+});
 
 /**
  * @typedef {object} PostalSvcTerms
@@ -12,8 +18,7 @@ const { keys, values } = Object;
 
 /** @param {ZCF<PostalSvcTerms>} zcf */
 export const start = zcf => {
-  const { namesByAddress, issuers } = zcf.getTerms();
-  mustMatch(namesByAddress, M.remotable('namesByAddress'));
+  const { namesByAddress, issuers } = getTerms(zcf, meta);
   console.log('postalSvc issuers', Object.keys(issuers));
 
   /**

--- a/contract/src/start-arbAssetName.js
+++ b/contract/src/start-arbAssetName.js
@@ -1,0 +1,51 @@
+// @ts-check
+import { E } from '@endo/far';
+import { AmountMath } from '@agoric/ertp/src/amountMath.js';
+
+/** @typedef {typeof import('./arbAssetNames.js').start} ContractFn */
+
+/**
+ * @param {BootstrapPowers} powers
+ * @param {{ assetNamingOptions: {
+ *   bundleID: string
+ *   stable?: string
+ *   price: number | bigint
+ *   unit?: number | bigint
+ * }}} config
+ */
+export const startArbAssetName = async (powers, config) => {
+  const {
+    consume: { zoe, board, agoricNamesAdmin },
+    instance: {
+      produce: { arbAssetName },
+    },
+    brand: { consume: brandConsume },
+    issuer: { consume: issuerConsume },
+  } = powers;
+  const {
+    assetNamingOptions: { bundleID, stable = 'IST', price, unit = 1n },
+  } = config;
+  /** @type {ERef<Installation<ContractFn>>} */
+  const installation = E(zoe).installBundleID(bundleID);
+  const issuers = { Price: await issuerConsume[stable] };
+  const terms = {
+    board: await board,
+    price: AmountMath.make(
+      await brandConsume[stable],
+      BigInt(price) * BigInt(unit),
+    ),
+  };
+  const privateArgs = {
+    nameAdmins: {
+      issuer: await E(agoricNamesAdmin).lookupAdmin('issuer'),
+      brand: await E(agoricNamesAdmin).lookupAdmin('brand'),
+    },
+  };
+  const startedKit = await E(zoe).startInstance(
+    installation,
+    issuers,
+    terms,
+    privateArgs,
+  );
+  arbAssetName.resolve(startedKit.instance);
+};

--- a/contract/test/test-arbAssetNames.js
+++ b/contract/test/test-arbAssetNames.js
@@ -1,0 +1,53 @@
+// @ts-check
+/* eslint-disable import/order -- https://github.com/endojs/endo/issues/1235 */
+// import { test } from './prepare-test-env-ava.js';
+import { test as anyTest } from './prepare-test-env-ava.js';
+import { createRequire } from 'module';
+
+import { E } from '@endo/far';
+import { makeNodeBundleCache } from '@endo/bundle-source/cache.js';
+import { makeIssuerKit, AmountMath } from '@agoric/ertp';
+import { makeBootstrapPowers, makeBundleCacheContext } from './boot-tools.js';
+
+/** @typedef {typeof import('../src/arbAssetNames.js').start} ContractFn */
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
+const test = anyTest;
+
+test.before(async t => (t.context = await makeBundleCacheContext(t)));
+
+const nodeRequire = createRequire(import.meta.url);
+
+const contractName = 'arbAssetNames';
+const assets = {
+  [contractName]: nodeRequire.resolve('../src/arbAssetNames.js'),
+};
+
+const idOf = b => `b1-${b.endoZipBase64Sha512}`;
+
+test('Start the contract', async t => {
+  const { bundleCache } = t.context;
+
+  const money = makeIssuerKit('PlayMoney');
+  const issuers = { Price: money.issuer };
+  const terms = { Price: AmountMath.make(money.brand, 5n) };
+  t.log('terms:', terms);
+
+  const { powers, vatAdminState } = await makeBootstrapPowers(t.log);
+  const bundle = await bundleCache.load(assets[contractName], contractName);
+  const bundleID = idOf(bundle);
+  t.log('publish bundle', bundleID.slice(0, 8));
+  vatAdminState.installBundle(bundleID, bundle);
+
+  const zoe = powers.consume.zoe;
+
+  /** @type {ERef<Installation<ContractFn>>} */
+  const installation = E(zoe).install(bundle);
+  const { instance } = await E(zoe).startInstance(installation, issuers, terms);
+  t.log(instance);
+  t.is(typeof instance, 'object');
+});
+
+test.todo('publish an issuer / brand');
+
+test('ok?', t => t.pass());

--- a/contract/test/test-arbAssetNames.js
+++ b/contract/test/test-arbAssetNames.js
@@ -4,12 +4,16 @@
 import { test as anyTest } from './prepare-test-env-ava.js';
 import { createRequire } from 'module';
 
+import { E } from '@endo/far';
 import {
   bootAndInstallBundles,
   getBundleId,
   makeBundleCacheContext,
 } from './boot-tools.js';
 import { startArbAssetName } from '../src/start-arbAssetName.js';
+import { mockWalletFactory } from './wallet-tools.js';
+import { launcherLarry } from './market-actors.js';
+import { makeStableFaucet } from './mintStable.js';
 
 /** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
 const test = anyTest;
@@ -23,19 +27,46 @@ const bundleRoots = {
   [contractName]: nodeRequire.resolve('../src/arbAssetNames.js'),
 };
 
-test('Start arbitrary asset naming contract', async t => {
+test('launcher Larry publishes his asset type', async t => {
   const { powers, bundles } = await bootAndInstallBundles(t, bundleRoots);
 
-  await startArbAssetName(powers, {
-    assetNamingOptions: {
-      bundleID: getBundleId(bundles[contractName]),
-      price: 100n,
-      unit: 1_000_000n,
-    },
-  });
+  const config = {
+    bundleID: getBundleId(bundles[contractName]),
+    price: 100n,
+    unit: 1_000_000n,
+  };
+  await startArbAssetName(powers, { assetNamingOptions: config });
   const instance = await powers.instance.consume.arbAssetName;
   t.log(instance);
   t.is(typeof instance, 'object');
+
+  const { agoricNames, zoe, namesByAddressAdmin, chainStorage, feeMintAccess } =
+    powers.consume;
+  const { price } = await E(zoe).getTerms(instance);
+  const wellKnown = {
+    installation: {},
+    instance: powers.instance.consume,
+    issuer: powers.issuer.consume,
+    brand: powers.brand.consume,
+    terms: { arbAssetName: { price } },
+  };
+
+  const walletFactory = mockWalletFactory(
+    { zoe, namesByAddressAdmin, chainStorage },
+    {
+      Invitation: await wellKnown.issuer.Invitation,
+      IST: await wellKnown.issuer.IST,
+    },
+  );
+  const { bundleCache } = t.context;
+  const { faucet } = makeStableFaucet({ feeMintAccess, zoe, bundleCache });
+  const funds = await E(faucet)(price.value * 2n);
+  const wallet = await walletFactory.makeSmartWallet('agoric1launcherLarry');
+  await E(wallet.deposit).receive(funds.withdraw(funds.getCurrentAmount()));
+  const info = await launcherLarry(t, { wallet }, wellKnown);
+  const publishedBrand = await E(agoricNames).lookup('brand', info.id);
+  t.log(info.brand, 'at', info.id);
+  t.is(publishedBrand, info.brand);
 });
 
 test.todo('publish an issuer / brand');


### PR DESCRIPTION
fixes #10 

story: Larry needs a way for people to make smart wallet offers to trade in the new BRD token he's launching (get it? :basketball: ). So he offers 100 IST to the **arbAssetName** contract to add BRD to agoricNames; it tells him (in the offer result) that the name there is **board0371**.

```
~/projects/ag-power-tools/contract$ TRACK_TURNS=enabled DEBUG=track-turns yarn test test/test-arbAssetNames.js
...
  ✔ launcher Larry publishes his asset type 
...
    ℹ publish bundle arbAssetNames b1-d7fc9
    ℹ instance arbAssetName: new Promise
    ℹ instance arbAssetName settled; remaining: []
    ℹ Object @Alleged: InstanceHandle {}
    ℹ Larry launched {
        brand: Object @Alleged: BRD brand {},
        issuer: Object @Alleged: BRD issuer {},
      }
    ℹ Larry offers {
        brand: Object @Alleged: ZDEFAULT brand {},
        value: 100000000n,
      } to publish
    ℹ Larry published as board0371
    ℹ Object @Alleged: BRD brand {} at board0371
```
