### PR TITLE
fix: updated test code to reference local prepare-test-env-ava.js file

### DIFF
--- a/contract/test/test-launchIt.js
+++ b/contract/test/test-launchIt.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test } from './prepare-test-env-ava.js';
+import { test as anyTest } from './prepare-test-env-ava.js';
 import { createRequire } from 'module';
 
 import { E } from '@endo/far';
@@ -27,6 +27,9 @@ const bundleRoots = {
   [contractName]: nodeRequire.resolve('../src/launchIt.js'),
   contractStarter: nodeRequire.resolve('../src/contractStarter.js'),
 };
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
+const test = anyTest;
 
 test.before(async t => (t.context = await makeBundleCacheContext(t)));
 

--- a/contract/test/test-launchIt.js
+++ b/contract/test/test-launchIt.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 import { createRequire } from 'module';
 
 import { E } from '@endo/far';
@@ -27,9 +27,6 @@ const bundleRoots = {
   [contractName]: nodeRequire.resolve('../src/launchIt.js'),
   contractStarter: nodeRequire.resolve('../src/contractStarter.js'),
 };
-
-/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
-const test = anyTest;
 
 test.before(async t => (t.context = await makeBundleCacheContext(t)));
 

--- a/contract/test/test-launchIt.js
+++ b/contract/test/test-launchIt.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test as anyTest } from './prepare-test-env-ava.js';
 import { createRequire } from 'module';
 
 import { E } from '@endo/far';

--- a/contract/test/test-postalSvc.js
+++ b/contract/test/test-postalSvc.js
@@ -1,7 +1,7 @@
 // @ts-check
 // XXX what's the state-of-the-art in ava setup?
 // eslint-disable-next-line import/order
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test as anyTest } from './prepare-test-env-ava.js';
 
 import { createRequire } from 'module';
 

--- a/contract/test/test-postalSvc.js
+++ b/contract/test/test-postalSvc.js
@@ -1,7 +1,7 @@
 // @ts-check
 // XXX what's the state-of-the-art in ava setup?
 // eslint-disable-next-line import/order
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 
 import { createRequire } from 'module';
 
@@ -23,9 +23,6 @@ import {
 } from './market-actors.js';
 
 const { entries, fromEntries, keys } = Object;
-
-/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
-const test = anyTest;
 
 const nodeRequire = createRequire(import.meta.url);
 

--- a/contract/test/test-postalSvc.js
+++ b/contract/test/test-postalSvc.js
@@ -24,14 +24,14 @@ import {
 
 const { entries, fromEntries, keys } = Object;
 
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
+const test = anyTest;
+
 const nodeRequire = createRequire(import.meta.url);
 
 const bundleRoots = {
   postalSvc: nodeRequire.resolve('../src/postalSvc.js'),
 };
-
-/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
-const test = anyTest;
 
 test.before(async t => (t.context = await makeBundleCacheContext(t)));
 

--- a/contract/test/test-postalSvc.js
+++ b/contract/test/test-postalSvc.js
@@ -1,7 +1,7 @@
 // @ts-check
 // XXX what's the state-of-the-art in ava setup?
 // eslint-disable-next-line import/order
-import { test } from './prepare-test-env-ava.js';
+import { test as anyTest } from './prepare-test-env-ava.js';
 
 import { createRequire } from 'module';
 
@@ -29,6 +29,9 @@ const nodeRequire = createRequire(import.meta.url);
 const bundleRoots = {
   postalSvc: nodeRequire.resolve('../src/postalSvc.js'),
 };
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
+const test = anyTest;
 
 test.before(async t => (t.context = await makeBundleCacheContext(t)));
 

--- a/contract/test/test-start1.js
+++ b/contract/test/test-start1.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test } from './prepare-test-env-ava.js';
 import { E } from '@endo/far';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { createRequire } from 'module';
@@ -26,9 +26,6 @@ const assets = {
   contractStarter: myRequire.resolve('../src/contractStarter.js'),
   postalSvc: myRequire.resolve('../src/postalSvc.js'),
 };
-
-/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
-const test = anyTest;
 
 test.before(async t => (t.context = await makeBundleCacheContext(t)));
 

--- a/contract/test/test-start1.js
+++ b/contract/test/test-start1.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test } from './prepare-test-env-ava.js';
+import { test as anyTest } from './prepare-test-env-ava.js';
 import { E } from '@endo/far';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { createRequire } from 'module';
@@ -26,6 +26,9 @@ const assets = {
   contractStarter: myRequire.resolve('../src/contractStarter.js'),
   postalSvc: myRequire.resolve('../src/postalSvc.js'),
 };
+
+/** @type {import('ava').TestFn<Awaited<ReturnType<makeBundleCacheContext>>>} */
+const test = anyTest;
 
 test.before(async t => (t.context = await makeBundleCacheContext(t)));
 

--- a/contract/test/test-start1.js
+++ b/contract/test/test-start1.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test as anyTest } from '@agoric/zoe/tools/prepare-test-env-ava.js';
+import { test as anyTest } from './prepare-test-env-ava.js';
 import { E } from '@endo/far';
 import { AmountMath, AssetKind } from '@agoric/ertp';
 import { createRequire } from 'module';


### PR DESCRIPTION
running `yarn test` from the contract directory failed to properly test launchIt and postalSvc. 

below shows what is logged to my console.

```sh
yarn run test
yarn run v1.22.19
$ ava --verbose

  Uncaught exception in test/test-launchIt.js

  AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: The expression evaluated to a falsy value:

    assert(refs.runnerChain)


  Uncaught exception in test/test-start1.js

  AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: The expression evaluated to a falsy value:

    assert(refs.runnerChain)


SES_UNHANDLED_REJECTION: (AssertionError#1)
SES_UNHANDLED_REJECTION: (AssertionError#1)
  Uncaught exception in test/test-postalSvc.js

  AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: The expression evaluated to a falsy value:

    assert(refs.runnerChain)


  ✘ test/test-start1.js exited with a non-zero exit code: 1
SES_UNHANDLED_REJECTION: (AssertionError#1)
  ✘ test/test-launchIt.js exited with a non-zero exit code: 1
  ✘ test/test-postalSvc.js exited with a non-zero exit code: 1
start-game1-proposal.js module evaluating

```


upon inspection, i noticed that these files referenced ava from `@agoric/zoe` whereas all other test files referenced the local version of the file, so i updated the code accordingly. now, running `yarn test` with these changes works as expected.

